### PR TITLE
More restrictive RegEx

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function getClasses(content) {
   return classes;
 }
 
-const classesRegex = /"([^"\\]+)":/g;
+const classesRegex = /"([^"\\/;()\n]+)":/g;
 
 /**
  * @param {string} [path]


### PR DESCRIPTION
As described in #5 I had trouble using PostCSS `@import`s (or asset imports). It turns out that a fix is as simple as making the RegEx a bit more restrictive.

In the current version the `classesRegex` basically looks for class name string between two double quotation marks (`"`) if it does not contain a backslash (`\`). This works if there's nothing else in the `content` that comes into this loader. In my case there was quite a bit more...

```
exports = module.exports = require("../../../node_modules/css-loader/dist/runtime/api.js")(false);
// Imports
var urlEscape = require("../../../node_modules/css-loader/dist/runtime/url-escape.js");
var ___CSS_LOADER_URL___0___ = urlEscape(require("assets/header/icon.svg"));

// Module
exports.push([module.id, ":root ...................
```

So, if we exclude a few more characters from potential class name strings, it works. Although only one of them would be enough for me, I added a few more characters that are definitely not allowed in a class name (`/`, `;`, `(`, `)`, `\n`), but likely to appear in other code that we want to ignore.