### PR TITLE
'exportName' option was introduced.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,30 @@ export interface I_buttonScss {
   'button': string
   'buttonActive': string
 }
-declare const styles: I_buttonScss;
+export const styles: I_buttonScss;
 export default styles;
 ```
+
+### `exportName`
+
+You can specify exported variable name if "namedExport" is switched off:
+```js
+{
+  test: /\.scss$/,
+  use: [
+    {
+      loader: 'dts-css-modules-loader',
+      options: {
+        exportName: 'classes'
+      }
+    },
+    // ...
+}
+```
+```ts
+import { classes } from './your.css';
+```
+This option is usefull if default exports are deprecated by your linter.
 
 ### `banner`
 Adds a "banner" prefix to each generated file.

--- a/index.js
+++ b/index.js
@@ -25,11 +25,12 @@ module.exports = function(content) {
       }
     } else {
       const i = getInterfaceName(this.resourcePath);
+      const exportName = options.exportName || 'styles';
       typings += `export interface ${i} {\n`;
       for (let c of classes) {
         typings += `  '${c}': string;\n`;
       }
-      typings += `}\ndeclare const styles: ${i};\nexport default styles;\n`;
+      typings += `}\nexport const ${exportName}: ${i};\nexport default ${exportName};\n`;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dts-css-modules-loader",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "webpack loader to generate typings for css modules",
   "dependencies": {
     "loader-utils": "^1.2.0"


### PR DESCRIPTION
Currently, default exports are deprecated in my project.

I think that css.d.ts file should export a namespace variable as an alternative way.

Also, I think that there should be an option to customize exported variable name.
