### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,14 @@
     "loader"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Megaputer/dts-css-modules-loader.git"
+  },
   "homepage": "https://github.com/Megaputer/dts-css-modules-loader",
+  "bugs": {
+    "url": "https://github.com/Megaputer/dts-css-modules-loader/issues"
+  },
   "devDependencies": {
     "@types/webpack": "^5.28.0"
   }


### PR DESCRIPTION
## Summary
- add public npm repository metadata
- add npm bugs link for the GitHub issue tracker
- leave runtime code, dependencies, package version, homepage, and package contents unchanged

## Validation
- `npm view dts-css-modules-loader@2.0.2 name version repository homepage bugs license main --json`
- package metadata assertion for `repository.url`, `bugs.url`, `homepage`, `name`, and `version`
- `npm pack --dry-run --ignore-scripts --json .`
- `npm install --ignore-scripts --no-audit --no-fund --package-lock=false`
- `git diff --check`

Note: this package does not define test or build scripts.